### PR TITLE
[RM4-20367] Fix row shift selection in selection.js

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -594,7 +594,12 @@
           for (var i = fromRow; i <= toRow; i++) {
             var rowToSelect = grid.renderContainers.body.visibleRowCache[i];
             if (rowToSelect) {
-              if (!rowToSelect.isSelected && rowToSelect.enableSelection !== false) {
+              if (
+                  !rowToSelect.isSelected
+                  && rowToSelect.enableSelection !== false
+                  && rowToSelect.entity.isHeader === false
+              )
+              {
                 rowToSelect.setSelected(true);
                 grid.selection.lastSelectedRow = rowToSelect;
                 service.decideRaiseSelectionEvent(grid, rowToSelect, changedRows, evt);


### PR DESCRIPTION
_General:_ 
`Shift+click` selection was not selecting the rows properly, because it was including the `header` rows as well. Header rows were not excluded in `shiftSelect`,

_What was happening before the change:_
The header rows exclusion was handled in the `onUiGridRowSelectionChangedBatch` `(frontend-redesign/rm-grid-core.class.ts)` which is a function raised when we do a shift select.
There we have `firstRowIsHeader` & `lastRowIsHeader` where we check if the row should be excluded from selection. 

`firstRowIsHeader` is the first row **after** the selected row (not the selected row), so in scenario when you select one row above the header row, the header row becomes the first row (first row after selected row) and then the `firstRowIsHeader` is `true` so it selects all the children of the row and the row itself.

_Why it was working when you select 2 or more rows above the header row?_
- In that case `firstRowIsHeader` is never true, because if you select 2 rows above the header row then the header row is the 2nd row and the flag is false so it does not select the children.

_Solution:_ 
I think that we should exclude the header rows in the `shiftSelect` function, so they are not even passed in the function mentioned above. 
