### PR TITLE
[RM4-35958] Fix row deselection on shift select and fix sendinng of selection event

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -583,6 +583,20 @@
           var selectedRows = service.getSelectedRows(grid);
           var fromRow = selectedRows.length > 0 ? grid.renderContainers.body.visibleRowCache.indexOf(grid.selection.lastSelectedRow) : 0;
           var toRow = grid.renderContainers.body.visibleRowCache.indexOf(row);
+
+	        // [RM4-35958] If a row is deselected with shift, we set only that row to false, fire the required event
+	        // And bail out, so that the rest remains unaffected
+	        if (toRow > -1) {
+		        const selectedRow = grid.renderContainers.body.visibleRowCache[toRow];
+		        if (selectedRow.isSelected && selectedRow.enableSelection !== false) {
+			        const changedRows = [];
+			        selectedRow.setSelected(false);
+			        service.decideRaiseSelectionEvent(grid, selectedRow, changedRows, evt);
+			        service.decideRaiseSelectionBatchEvent(grid, changedRows, evt);
+			        return;
+		        }
+	        }
+
           // reverse select direction
           if (fromRow > toRow) {
             var tmp = fromRow;


### PR DESCRIPTION
The behaviour in Rentman regarding shift clicking rows is as follows:

- If you shift click an unselected row, it will select everything underneath it, if you shift click a selected row it will only unselect that row and keep the rest selected, even if it's a group container
- In ui-grid currently it does not set the shift click deselected row as deselected internally and does not send an event, this implementation fixes that